### PR TITLE
added missing package reference to `clone`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "syslog-streams2": "^1.0.0",
     "udp-streams2": "^1.0.3",
-    "unix-socket-streams2": "^1.0.3"
+    "unix-socket-streams2": "^1.0.3",
+    "clone": "^0.2.0"
   },
   "devDependencies": {
     "mocha": "^2.0.1",


### PR DESCRIPTION
While testing syslog2 I noticed there was no npm reference to `clone`.