### PR TITLE
Fix docs to reflect correct usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ This module presents as a Node (streams2) writable stream, and outputs to Syslog
 # Usage
 
     var Syslog = require('syslog2');
-	var log = new Syslog();
+	var log = Syslog.create();
 
 	log.write('message');
+
+`Syslog.create(options, callback)` is a shortcut for `new Syslog(options)`
+followed by `.connect(callback)`.
 
 # Options
 


### PR DESCRIPTION
The way the example in the README is currently written, it's effectively a no-op.  This fixes the example to actually open the connection to syslog and send it some data.  It also adds a short blurb explaining the difference.