### PR TITLE
README: objects in the stream should have 'message' not 'msg'

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This will generate the header field according to the options created on instanti
 You may write any object to the stream, but the following keys have special meaning:
 
     {
-		msg: <message>,
+		message: <message>,
 		level: <log level>,
 		time: <timestamp>,
 		hostname: <originating hostname>,


### PR DESCRIPTION
Having 'msg' makes it into a banyan object, which is not what is
expected from the documentation. Also we talk about 'message' below when
explaining it.